### PR TITLE
Modular mobile menu fix

### DIFF
--- a/templates/modular.html.twig
+++ b/templates/modular.html.twig
@@ -27,7 +27,7 @@
 
 {% block header_navigation %}
     {% if show_onpage_menu %}
-        <ul class="navigation">
+        <ul class="navigation{{ tree ? ' tree' : '' }}">
         {% for module in page.collection() %}
             {% set current_module = (module.active or module.activeChild) ? 'active' : '' %}
             <li><a class="{{ current_module }}" href="#{{ _self.pageLinkName(module.menu) }}">{{ module.menu }}</a></li>

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -96,7 +96,9 @@
                 {% include('@images/grav-logo.svg') %}
             </div>
             <nav class="overlay-menu">
-                {% include 'partials/navigation.html.twig' with {tree: true} %}
+                {% with {tree: true} %}
+                    {{ block('header_navigation') }}
+                {% endwith %}
             </nav>
         </div>
     </div>


### PR DESCRIPTION
Change base html twig to use header_navigation block with tree: true for mobile-menu.  This allows modular one-page sites to have a working menu on mobile.