### PR TITLE
Fix inheritance for images folder

### DIFF
--- a/quark.php
+++ b/quark.php
@@ -24,7 +24,7 @@ class Quark extends Theme
     public function onTwigLoader()
     {
         $theme_paths = Grav::instance()['locator']->findResources('theme://images');
-        foreach(array_reverse($theme_paths) as $images_path) {
+        foreach($theme_paths as $images_path) {
             $this->grav['twig']->addPath($images_path, 'images');
         }
     }


### PR DESCRIPTION
findResources returns the parent theme's location first and Twig matches on the first path it finds, so *not* reversing the order is actually the correct thing to do.

This reverts commit 81af4aa5c4c5abef9f74a351b36499ebac8f54bf.