### PR TITLE
Fix fallback values and load order for blog settings

### DIFF
--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -1,9 +1,9 @@
 {% extends 'partials/base.html.twig' %}
 {% set blog_image = page.media.images[page.header.hero_image] ?: page.media.images|first %}
 {% set collection = page.collection() %}
-{% set show_breadcrumbs = header_var('show_sidebar', '/blog')|default(true) %}
-{% set show_sidebar = header_var('show_sidebar')|default(true) %}
-{% set show_pagination = header_var('show_sidebar')|default(true) %}
+{% set show_breadcrumbs = header_var('show_sidebar', '/blog')|defined(true) %}
+{% set show_sidebar = header_var('show_sidebar')|defined(true) %}
+{% set show_pagination = header_var('show_sidebar')|defined(true) %}
 
 {% block stylesheets %}
     {% do assets.addCss('theme://css/bricklayer.css') %}

--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -1,9 +1,10 @@
 {% extends 'partials/base.html.twig' %}
 {% set blog_image = page.media.images[page.header.hero_image] ?: page.media.images|first %}
 {% set collection = page.collection() %}
-{% set show_breadcrumbs = header_var('show_breadcrumbs', '/blog')|defined(true) %}
-{% set show_sidebar = header_var('show_sidebar')|defined(true) %}
-{% set show_pagination = header_var('show_pagination')|defined(true) %}
+{% set blog = page.find(header_var('blog_url')|defined(theme_var('blog-page'))) %}
+{% set show_breadcrumbs = header_var('show_breadcrumbs', [page, blog])|defined(true) %}
+{% set show_sidebar = header_var('show_sidebar', [page, blog])|defined(true)  %}
+{% set show_pagination = header_var('show_pagination', [page, blog])|defined(true) %}
 
 {% block stylesheets %}
     {% do assets.addCss('theme://css/bricklayer.css') %}

--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -1,9 +1,9 @@
 {% extends 'partials/base.html.twig' %}
 {% set blog_image = page.media.images[page.header.hero_image] ?: page.media.images|first %}
 {% set collection = page.collection() %}
-{% set show_breadcrumbs = header_var('show_sidebar', '/blog')|defined(true) %}
+{% set show_breadcrumbs = header_var('show_breadcrumbs', '/blog')|defined(true) %}
 {% set show_sidebar = header_var('show_sidebar')|defined(true) %}
-{% set show_pagination = header_var('show_sidebar')|defined(true) %}
+{% set show_pagination = header_var('show_pagination')|defined(true) %}
 
 {% block stylesheets %}
     {% do assets.addCss('theme://css/bricklayer.css') %}

--- a/templates/item.html.twig
+++ b/templates/item.html.twig
@@ -1,8 +1,8 @@
 {% extends 'partials/base.html.twig' %}
-{% set blog = page.find(theme_var('blog-page')) %}
-{% set show_breadcrumbs = header_var('show_breadcrumbs', [page, blog]) %}
-{% set show_sidebar = header_var('show_sidebar', [page, blog])  %}
-{% set show_pagination = header_var('show_pagination', [page, blog]) %}
+{% set blog = page.find(header_var('blog_url')|defined(theme_var('blog-page'))) %}
+{% set show_breadcrumbs = header_var('show_breadcrumbs', [page, blog])|defined(true) %}
+{% set show_sidebar = header_var('show_sidebar', [page, blog])|defined(true)  %}
+{% set show_pagination = header_var('show_pagination', [page, blog])|defined(true) %}
 {% set hero_image_name = page.header.hero_image %}
 
 {% block hero %}

--- a/templates/item.html.twig
+++ b/templates/item.html.twig
@@ -1,5 +1,5 @@
 {% extends 'partials/base.html.twig' %}
-{% set blog = page.find(theme_var('blog-page')|default('/blog')) %}
+{% set blog = page.find(theme_var('blog-page')) %}
 {% set show_breadcrumbs = header_var('show_breadcrumbs', [page, blog]) %}
 {% set show_sidebar = header_var('show_sidebar', [page, blog])  %}
 {% set show_pagination = header_var('show_pagination', [page, blog]) %}

--- a/templates/item.html.twig
+++ b/templates/item.html.twig
@@ -39,4 +39,3 @@
     </section>
 </section>
 {% endblock %}
-


### PR DESCRIPTION
This PR makes sure

 * the correct variable names are used for the blog settings (#22)
 * the correct fallback-mechanism is used for the blog settings (#25)
 * Blog settings are always searched for in the following order:
   - Header variables in the current page
   - Settings from the page listed in the current page's header variable `blog_url`
   - Settings from the page listed in the theme variable `blog-page` (which defaults to `/blog`)
   - Default value (true)

Fixes #22
Obsoletes/Fixes #25