### PR TITLE
Make blog settings toggleable

### DIFF
--- a/blueprints/partials/blog-bits.yaml
+++ b/blueprints/partials/blog-bits.yaml
@@ -25,7 +25,7 @@ form:
       type: text
       toggleable: true
       label: Blog Route
-      help: The route to this main blog page that contains this configuration
+      help: The route to the main blog page that contains the "Show ..." configuration
       default: '/blog'
       placeholder: '/blog'
       size: medium

--- a/blueprints/partials/blog-bits.yaml
+++ b/blueprints/partials/blog-bits.yaml
@@ -23,6 +23,7 @@ form:
 
     header.blog_url:
       type: text
+      toggleable: true
       label: Blog Route
       help: The route to this main blog page that contains this configuration
       default: '/blog'
@@ -31,9 +32,9 @@ form:
 
     header.show_sidebar:
       type: toggle
+      toggleable: true
       label: Show Sidebar
       highlight: 1
-      default: 1
       options:
         1: PLUGIN_ADMIN.ENABLED
         0: PLUGIN_ADMIN.DISABLED
@@ -42,9 +43,9 @@ form:
 
     header.show_breadcrumbs:
       type: toggle
+      toggleable: true
       label: Show Breadcrumbs
       highlight: 1
-      default: 1
       options:
         1: PLUGIN_ADMIN.ENABLED
         0: PLUGIN_ADMIN.DISABLED
@@ -53,9 +54,9 @@ form:
 
     header.show_pagination:
       type: toggle
+      toggleable: true
       label: Show Pagination
       highlight: 1
-      default: 1
       options:
         1: PLUGIN_ADMIN.ENABLED
         0: PLUGIN_ADMIN.DISABLED


### PR DESCRIPTION
This PR prevents the admin plugin from adding these settings to blog pages and items automatically, overwriting an already existing inheritance (for example using the `blog-page` theme variable).

I've also slightly reworded the help text for `blog_url` to make it clearer.

Fixes #36