### PR TITLE
Move footer to separate twig

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -85,7 +85,9 @@
 
     </div>
 
+    {% block footer %}
     {% include 'partials/footer.html.twig' %}
+    {% endblock
     
     <div class="mobile-container">
         <div class="overlay" id="overlay">

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -46,9 +46,9 @@
                     <section class="navbar-section">
 
                         <nav class="dropmenu animated">
-                            {% block header_navigation %}
-                        {% include 'partials/navigation.html.twig' %}
-                            {% endblock %}
+                        {% block header_navigation %}
+                            {% include 'partials/navigation.html.twig' %}
+                        {% endblock %}
                         </nav>
 
                         {% if config.plugins.login.enabled and grav.user.username %}
@@ -86,7 +86,7 @@
     </div>
 
     {% block footer %}
-    {% include 'partials/footer.html.twig' %}
+        {% include 'partials/footer.html.twig' %}
     {% endblock
     
     <div class="mobile-container">

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -85,7 +85,7 @@
 
     </div>
 
-	{% include 'partials/footer.html.twig' %}
+    {% include 'partials/footer.html.twig' %}
     
     <div class="mobile-container">
         <div class="overlay" id="overlay">

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -85,14 +85,7 @@
 
     </div>
 
-{% block footer %}
-    <section id="footer" class="section bg-gray">
-        <section class="container {{ grid_size }}">
-            <p><a href="http://getgrav.org">Grav</a> was <i class="fa fa-code"></i> with <i class="fa fa-heart-o pulse "></i> by <a href="https://trilby.media">Trilby Media</a>.</p>
-        </section>
-    </section>
-{% endblock %}
-
+	{% include 'partials/footer.html.twig' %}
     
     <div class="mobile-container">
         <div class="overlay" id="overlay">

--- a/templates/partials/footer.html.twig
+++ b/templates/partials/footer.html.twig
@@ -1,7 +1,6 @@
-{% block footer %}
-    <section id="footer" class="section bg-gray">
-        <section class="container {{ grid_size }}">
-            <p><a href="http://getgrav.org">Grav</a> was <i class="fa fa-code"></i> with <i class="fa fa-heart-o pulse "></i> by <a href="https://trilby.media">Trilby Media</a>.</p>
-        </section>
+
+<section id="footer" class="section bg-gray">
+    <section class="container {{ grid_size }}">
+        <p><a href="http://getgrav.org">Grav</a> was <i class="fa fa-code"></i> with <i class="fa fa-heart-o pulse "></i> by <a href="https://trilby.media">Trilby Media</a>.</p>
     </section>
-{% endblock %}
+</section>

--- a/templates/partials/footer.html.twig
+++ b/templates/partials/footer.html.twig
@@ -1,4 +1,3 @@
-
 <section id="footer" class="section bg-gray">
     <section class="container {{ grid_size }}">
         <p><a href="http://getgrav.org">Grav</a> was <i class="fa fa-code"></i> with <i class="fa fa-heart-o pulse "></i> by <a href="https://trilby.media">Trilby Media</a>.</p>

--- a/templates/partials/footer.html.twig
+++ b/templates/partials/footer.html.twig
@@ -1,0 +1,7 @@
+{% block footer %}
+    <section id="footer" class="section bg-gray">
+        <section class="container {{ grid_size }}">
+            <p><a href="http://getgrav.org">Grav</a> was <i class="fa fa-code"></i> with <i class="fa fa-heart-o pulse "></i> by <a href="https://trilby.media">Trilby Media</a>.</p>
+        </section>
+    </section>
+{% endblock %}


### PR DESCRIPTION
As explained in issue #62 extracting the site footer to a twig would make customization easier. This PR contains the corresponding modification.