### PR TITLE
Change field name in blueprint for modular features

### DIFF
--- a/blueprints/modular/features.yaml
+++ b/blueprints/modular/features.yaml
@@ -9,7 +9,7 @@ form:
           type: tab
           title: Features
           fields:
-            class:
+            header.class:
               type: select
               label: Layout
               default: small


### PR DESCRIPTION
This seems to be required to get the layout size admin option to actually write something to the front matter.