### PR TITLE
Change nav_loop macro to not assign empty class tags on inactive anchors

### DIFF
--- a/templates/macros/macros.html.twig
+++ b/templates/macros/macros.html.twig
@@ -1,10 +1,10 @@
 {% macro nav_loop(page) %}
   {% import _self as macros %}
   {% for p in page.children.visible %}
-    {% set active_page = (p.active or p.activeChild) ? 'active' : '' %}
+    {% set active_page = (p.active or p.activeChild) ? ' class="active"' : '' %}
     {% if p.children.visible.count > 0 %}
       <li>
-        <a href="{{ p.url }}" class="{{ active_page }}">
+        <a href="{{ p.url }}"{{ active_page }}>
           {{ p.menu }}
         </a>
         <ul>
@@ -13,7 +13,7 @@
       </li>
     {% else %}
       <li>
-        <a href="{{ p.url }}" class="{{ active_page }}">
+        <a href="{{ p.url }}"{{ active_page }}>
           {{ p.menu }}
         </a>
       </li>


### PR DESCRIPTION
Hello, I modified this macro so that it will not insert an empty class attribute (`class=""`) on anchors that are not active in the navigation bar. I did this by moving the class attribute in its entirety into the true conditional result of the ternary for the `active_page`'s variable assignment, like so `' class="active"'`.