### PR TITLE
Fix taxonomy label URL

### DIFF
--- a/templates/partials/blog/taxonomy.html.twig
+++ b/templates/partials/blog/taxonomy.html.twig
@@ -1,7 +1,7 @@
 {% if page.taxonomy.tag %}
 <span class="tags">
     {% for tag in page.taxonomy.tag %}
-    <a class="label label-rounded {{ label_style ?: 'label-secondary' }} p-category" href="{{ blog.url|rtrim('/') }}/tag{{ config.system.param_sep }}{{ tag }}#body-wrapper">{{ tag }}</a>
+    <a class="label label-rounded {{ label_style ?: 'label-secondary' }} p-category" href="{{ page.parent.url |rtrim('/') }}/tag{{ config.system.param_sep }}{{ tag }}#body-wrapper">{{ tag }}</a>
     {% endfor %}
 </span>
 {% endif %}


### PR DESCRIPTION
Issue:
In a blog item page, the taxonomy labels always point to the `blog.url`. It does not work well with a website with multiple blog-type pages. Different blogs can have their own blog root. A taxonomy at `/blog1/item1` should point to `/blog1`, and `/blog2/item1` should point to `/blog2` respectively.
Fix:
Always point the taxonomy URL to the parent page.