### PR TITLE
Update _blog.scss

### DIFF
--- a/scss/theme/_blog.scss
+++ b/scss/theme/_blog.scss
@@ -92,6 +92,7 @@ ul.pagination {
   ul.related-pages {
     box-shadow: none;
     padding: 0;
+    z-index: 1;
 
     li {
       border-bottom: 1px solid $border-color;

--- a/templates/partials/hero.html.twig
+++ b/templates/partials/hero.html.twig
@@ -1,4 +1,4 @@
-<section id="{{ id }}" class="section modular-hero hero {{ page.header.hero_classes }} {{ page.header.background.parallax ? 'parallax' : '' }}" {% if hero_image %}style="background-image: url({{ hero_image.url }});"{% endif %}>
+<section id="{{ id }}" class="section modular-hero hero {{ page.header.hero_classes }} {{ page.header.background.parallax ? 'parallax' : '' }}" {% if hero_image %}style="background-image: url('{{ hero_image.url }}');"{% endif %}>
     <div class="image-overlay"></div>
     <section class="container {{ grid_size }}" style="text-align: {{ page.header.hero_align|default('center') }}">
         {{ content|raw }}


### PR DESCRIPTION
&lt;ul class=&quot;related-pages menu&quot;&gt; in &quot;templates/partials/relatedpages.html.twig&quot; is inheriting .menu z-index (300). Making it blocking sticky header