### PR TITLE
Added missing html-closing tag to base template

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -105,3 +105,4 @@
 {% endblock %}
 
 </body>
+</html>


### PR DESCRIPTION
The base template does not included a closing `html`-tag.