### PR TITLE
prevent blog from breaking if specified hero_image is missing. Fixes Issue #87

### DIFF
--- a/templates/partials/blog-list-item.html.twig
+++ b/templates/partials/blog-list-item.html.twig
@@ -1,10 +1,8 @@
 <div class="card">
     {% set image = page.media.images|first %}
-    {% if image %}
     <div class="card-image">
         <a href="{{ page.url }}">{{ image.cropZoom(800,400).html }}</a>
     </div>
-    {% endif %}
     <div class="card-header">
         <div class="card-subtitle text-gray">
             {% include 'partials/blog/date.html.twig' %}
@@ -19,6 +17,7 @@
         {% else %}
             {{ page.content|raw }}
         {% endif %}
+<!-- {{ page.media.images|first }} -->
     </div>
     <div class="card-footer">
         {% include 'partials/blog/taxonomy.html.twig' %}


### PR DESCRIPTION
…Issue #87 
Previously, a missing hero_image caused a blog to crash horribly, exposing username and path names of a production server, and causing the website to be nonfunctional. The error is:

> Server Error
> 
> Sorry, something went terribly wrong!
> 0 - SplFileInfo::getMTime(): stat failed for /home/$MY_ACTUAL_USERNAME/public_html/MYSITE/PATH/01.blog/POST_DIR/IMAGE.jpg
> For further details please review your logs/ folder, or enable displaying of errors in your system configuration.
> 

This PR fixes the problem and allows the vendor/GregWar module to generate a fallback.jpg image in path  ``images/f/a/l/l/b``

In no case does the site crash, and as long as the user places an actual image in that path, the blog list does not display an error, but the fallback.jpg image.