### PR TITLE
Add toggle for blocking search indexing of Grav URL parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Quark comes with a few default options that can be set site-wide.  These options
 enabled: true                 # Enable the theme
 production-mode: true         # In production mode, only minified CSS is used. When disabled, nested CSS with sourcemaps are enabled
 grid-size: grid-lg            # The max-width of the theme, options include: `grid-xl`, `grid-lg`, and `grid-md`
+noindex_url_params: false     # When enabled, block search indexing for Grav URL parameters
 header-fixed: true            # Cause the header to be fixed at the top of the browser
 header-animated: true         # Allows the fixed header to resize to a smaller header when scrolled
 header-dark: false            # Inverts the text/logo to work better on dark backgrounds
@@ -68,6 +69,17 @@ custom_logo_mobile:           # A custom logo to use for mobile navigation
 To make modifications, you can copy the `user/themes/quark/quark.yaml` file to `user/config/themes/` folder and modify, or you can use the admin plugin.
 
 > NOTE: Do not modify the `user/themes/quark/quark.yaml` file directly or your changes will be lost with any updates
+
+## Block search indexing for Grav URL parameters
+
+When enabled, a `noindex` `<meta>` tag will be added to pages with Grav URL parameters (e.g. `/blog/foo:bar`).
+This is particularly useful to avoid page duplicates being indexed by search engines when there are filter links reachable from the main collection page (e.g. sidebar with Taxonomy List or Archives plugins).
+
+The theme-level setting can also be overridden at the page-level via YAML front matter:
+
+```yaml
+noindex_url_params: true
+```
 
 ## Custom Logos
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -44,6 +44,20 @@ form:
         grid-lg: Large
         grid-md: Medium
 
+    noindex_url_params:
+      type: toggle
+      label: Block search indexing for Grav URL parameters
+      help: |
+        When enabled, a 'noindex' <meta> tag will be added to pages with Grav URL parameters (e.g. '/blog/foo:bar').
+        This is particularly useful to avoid page duplicates being indexed by search engines when there are filter links reachable from the main collection page (e.g. sidebar with Taxonomy List or Archives plugins).
+      highlight: 0
+      default: 0
+      options:
+        1: PLUGIN_ADMIN.ENABLED
+        0: PLUGIN_ADMIN.DISABLED
+      validate:
+        type: bool
+
     header_section:
       type: section
       title: Header Defaults

--- a/blueprints/default.yaml
+++ b/blueprints/default.yaml
@@ -9,7 +9,7 @@ form:
             columns:
               fields:
                 column1:
-                   fields:
-                     header.body_classes:
-                       markdown: true
-                       description: 'Available classes in Quark Theme (space separated):<br />`header-fixed`, `header-animated`, `header-dark`, `header-transparent`, `sticky-footer`'
+                  fields:
+                    header.body_classes:
+                      markdown: true
+                      description: "Available classes in Quark Theme (space separated):<br />`header-fixed`, `header-animated`, `header-dark`, `header-transparent`, `sticky-footer`"

--- a/blueprints/default.yaml
+++ b/blueprints/default.yaml
@@ -13,3 +13,17 @@ form:
                     header.body_classes:
                       markdown: true
                       description: "Available classes in Quark Theme (space separated):<br />`header-fixed`, `header-animated`, `header-dark`, `header-transparent`, `sticky-footer`"
+                    header.noindex_url_params:
+                      type: toggle
+                      toggleable: true
+                      label: Block search indexing for Grav URL parameters
+                      help: |
+                        When enabled, a 'noindex' <meta> tag will be added to pages with Grav URL parameters (e.g. '/blog/foo:bar').
+                        This is particularly useful to avoid page duplicates being indexed by search engines when there are filter links reachable from the main collection page (e.g. sidebar with Taxonomy List or Archives plugins).
+                      highlight: 0
+                      default: 0
+                      options:
+                        1: PLUGIN_ADMIN.ENABLED
+                        0: PLUGIN_ADMIN.DISABLED
+                      validate:
+                        type: bool

--- a/quark.yaml
+++ b/quark.yaml
@@ -1,6 +1,7 @@
 enabled: true
 production-mode: true
 grid-size: grid-lg
+noindex_url_params: false
 header-fixed: true
 header-animated: true
 header-dark: false

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -12,6 +12,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% include 'partials/metadata.html.twig' %}
+    {% if header_var('noindex_url_params')|defined(theme_var('noindex_url_params'))|defined(false) and uri.params is not empty -%}
+    <meta name="robots" content="noindex">
+    {% endif %}
 
     <link rel="icon" type="image/png" href="{{ url('theme://images/favicon.png') }}" />
     <link rel="canonical" href="{{ page.url(true, true) }}" />


### PR DESCRIPTION
When enabled, a `noindex` `<meta>` tag will be added to pages with Grav URL parameters (e.g. `/blog/foo:bar`).

Rationale: avoid page duplicates being indexed by search engines.

I noticed this was happening when parameterized URLs were scrapable by search engines, which is the case by default on Quark with sidebar using Taxonomy List and Archives plugins.

It seems that at least Google treats them as separate pages, even when properly using canonical link elements and sitemaps.

As specified in [Google's documentation](https://support.google.com/webmasters/answer/139066?hl=en), the indexer may choose to ignore content-provided indicators:

> Google chooses the canonical page based on a number of factors (or signals), such as whether the page is served via http or https; page quality; presence of the URL in a sitemap; and any "rel=canonical" labeling. You can indicate your preference to Google using these techniques, but Google may choose a different page as canonical than you do, for various reasons.

This behavior might be undesirable. In this case, the only resort is to block indexing altogether [using a `noindex` `<meta>` tag](https://support.google.com/webmasters/answer/93710?hl=en):

<!-- prettier-ignore -->
```html
<meta name="robots" content="noindex">
```

Obviously, we'd only want to block indexing for Grav parameterized URLs. Including the `<meta>` tag in a base template is not suitable: it must be conditionally inserted.

Hence this toggle.