### PR TITLE
Use taxonomy value date format setting

### DIFF
--- a/templates/partials/archives.html.twig
+++ b/templates/partials/archives.html.twig
@@ -2,7 +2,7 @@
 
 {% for month,items in archives_data %}
     <li>
-    	<a href="{{ base_url }}/{{ config.plugins.archives.taxonomy_names.month }}{{ config.system.param_sep }}{{ month|date('M_Y')|lower|e('url') }}">
+    	<a href="{{ base_url }}/{{ config.plugins.archives.taxonomy_names.month }}{{ config.system.param_sep }}{{ month|date(config.plugins.archives.taxonomy_values.month)|lower|e('url') }}">
         {% if archives_show_count %}
         <span class="label label-rounded label-primary">{{ items|length }}</span>
         {% endif %}


### PR DESCRIPTION
Take advantage of taxonomy_values format coming from the archives plugin settings.
See https://github.com/getgrav/grav-plugin-archives/pull/29 for details.