### PR TITLE
Remove inline JS and CSS

### DIFF
--- a/js/bricklayer.loader.js
+++ b/js/bricklayer.loader.js
@@ -1,0 +1,1 @@
+var bricklayer = new Bricklayer(document.querySelector('.bricklayer'))

--- a/js/singlepagenav.loader.js
+++ b/js/singlepagenav.loader.js
@@ -1,0 +1,7 @@
+// singlePageNav initialization & configuration
+$('ul.navigation').singlePageNav({
+    offset: $('#header').outerHeight(),
+    filter: ':not(.external)',
+    updateHash: true,
+    currentClass: 'active'
+});

--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -15,6 +15,7 @@
     {{ parent() }}
     {% do assets.add('theme://js/bricklayer.min.js') %}
     {% do assets.add('theme://js/scopedQuerySelectorShim.min.js') %}
+    {% do assets.add('theme://js/bricklayer.loader.js', {group:'bottom-bl'}) %}
 {% endblock %}
 
 
@@ -53,10 +54,7 @@
         {% endembed %}
         </section>
     </section>
-    <script>
-        //Bricklayer
-        var bricklayer = new Bricklayer(document.querySelector('.bricklayer'))
-    </script>
+    {% do assets.add('theme://js/bricklayer.loader.js', {group:'bottom-bl'}) %}
 {% endblock %}
 
 

--- a/templates/modular.html.twig
+++ b/templates/modular.html.twig
@@ -5,6 +5,7 @@
 {% block javascripts %}
     {% if show_onpage_menu %}
         {% do assets.add('theme://js/singlepagenav.min.js') %}
+        {% do assets.add('theme://js/singlepagenav.loader.js', {group:'singlepage'}) %}
     {% endif %}
     {{ parent() }}
 {% endblock %}
@@ -12,15 +13,7 @@
 {% block bottom %}
     {{ parent() }}
     {% if show_onpage_menu %}
-        <script>
-        // singlePageNav initialization & configuration
-        $('ul.navigation').singlePageNav({
-            offset: $('#header').outerHeight(),
-            filter: ':not(.external)',
-            updateHash: true,
-            currentClass: 'active'
-        });
-        </script>
+        {{ assets.js('singlepage', {'loading': 'defer'})|raw }}
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
In order to comply with stricter content-security-policies, move the JS and CSS to their own files. Still WIP

Progress

- [x] Javascript
    - [x] Bricklayer in blog.html.twig
    - [x] Singlepage in modular.html.twig
    - [x] Full testing
- [ ] Inline CSS
    - [ ] Hero partial (background-image)
    - [ ] Checkbox form field
    - [ ] Full testing