### PR TITLE
Configurable favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ header-dark: false            # Inverts the text/logo to work better on dark bac
 header-transparent: false     # Allows the fixed header to be transparent over the page
 sticky-footer: true           # Causes the footer to be sticky at the bottom of the page
 blog-page: '/blog'            # The route to the blog listing page, useful for a blog style layout with sidebar
-custom_logo:                  # A custom logo rather than the default (see below)  
+custom_logo:                  # A custom logo rather than the default (see below)
 custom_logo_mobile:           # A custom logo to use for mobile navigation
+custom_favicon:               # A custom favicon rather than the default (see below)
 ```
 
 To make modifications, you can copy the `user/themes/quark/quark.yaml` file to `user/config/themes/` folder and modify, or you can use the admin plugin.
@@ -71,13 +72,15 @@ To make modifications, you can copy the `user/themes/quark/quark.yaml` file to `
 
 ## Custom Logos
 
-To add a custom logo, you should put the log into the `user/themes/quark/images/logo` folder.  Standard image formats are support (`.png`,`.jpg`, `.gif`, `.svg`, etc.).  Then reference the logo via the YAML like so:
+To add a custom logo or favicon, you should put the log into the `user/themes/quark/images/logo` folder.  Standard image formats are support (`.png`,`.jpg`, `.gif`, `.svg`, etc.).  Then reference the logo via the YAML like so:
 
 ```yaml
 custom_logo:
     - name: 'my-logo.png'
 custom_logo_mobile:
-    - name: 'my-mobile-logo.png'    
+    - name: 'my-mobile-logo.png'
+custom_favicon:
+    - name: 'my-favicon.png'
 ```
 
 Alternatively, you can you use the drag-n-drop "Custom Logo" field in the Quark theme options.

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -69,6 +69,18 @@ form:
       accept:
         - image/*
 
+    custom_favicon:
+      type: file
+      label: Custom Favicon
+      size: large
+      destination: 'theme://images/logo'
+      multiple: false
+      markdown: true
+      description: Will be used instead of default favicon `theme://images/favicon.png`. See <a href="https://en.wikipedia.org/wiki/Favicon" target="_blank">Favicon</a> for more details.
+      accept:
+        - image/*
+        - application/octet-stream
+
     header-fixed:
       type: toggle
       label: Fixed header

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -13,7 +13,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% include 'partials/metadata.html.twig' %}
 
-    <link rel="icon" type="image/png" href="{{ url('theme://images/favicon.png') }}" />
+    {% set favicon = theme_var('custom_favicon') %}
+    <link rel="icon" type="{% if favicon %}{{ (favicon|first).type }}{% else %}image/png{% endif %}" href="{% if favicon %}{{ url('theme://images/logo/' ~ (favicon|first).name) }}{% else %}{{ url('theme://images/favicon.png') }}{% endif %}" />
     <link rel="canonical" href="{{ page.url(true, true) }}" />
 {% endblock head %}
 


### PR DESCRIPTION
This mod adds new configuration parameter `custom_favicon` that allows
one to set custom favicon (similar to setting custom logos).

Note: `application/octet-stream` is accepted to allow .ico file
uploads from gnome file manager.

Author-Change-Id: IB#1118423