### PR TITLE
Accessibility on menu and page structure

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -51,6 +51,9 @@ jQuery(document).ready(function($){
         $(this).toggleClass('active');
         $('#overlay').toggleClass('open');
         $('body').toggleClass('mobile-nav-open');
+        // accessible toggle
+        var state = $('#toggle').attr('aria-expanded');
+        state == 'true' ? $('#toggle').attr('aria-expanded','false') : $('#toggle').attr('aria-expanded','true');
     });
 
     // Tree Menu

--- a/scss/theme/_menu.scss
+++ b/scss/theme/_menu.scss
@@ -39,9 +39,16 @@
             content: '';
           }
         }
+        &:focus + ul {
+            display: block;
+            visibility: visible;
+            opacity: 1;
+            transform: translateY(0);
+        }
+
       }
 
-      &:hover {
+      &:hover, &:focus-within {
         & > ul {
           display: block;
           visibility: visible;

--- a/templates/macros/macros.html.twig
+++ b/templates/macros/macros.html.twig
@@ -3,13 +3,17 @@
   {% for p in page.children.visible %}
     {% set active_page = (p.active or p.activeChild) ? 'active' : '' %}
     <li>
-      <a href="{{ p.url }}" class="{{ active_page }}">
+      {% if p.children.visible.count > 0 %}
+      <a tabindex="0" role="button" class="{{ active_page }}" {%if p.active %}aria-current="page"{% endif %}>
         {{ p.menu }}
       </a>
-      {% if p.children.visible.count > 0 %}
       <ul>
         {{ macros.nav_loop(p) }}
       </ul>
+      {% else %}
+        <a href="{{ p.url }}" class="{{ active_page }}" {%if p.active %}aria-current="page"{% endif %}>
+        {{ p.menu }}
+        </a>
       {% endif %}
     </li>
   {% endfor %}

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -40,30 +40,30 @@
 <body id="top" class="{% block body_classes %}{{ body_classes }}{% endblock %}">
     <div id="page-wrapper">
     {% block header %}
-        <section id="header" class="section">
-            <section class="container {{ grid_size }}">
+        <div id="header" class="section">
+            <div class="container {{ grid_size }}">
                 <nav class="navbar">
-                    <section class="navbar-section logo">
+                    <div class="navbar-section logo">
                         {% include 'partials/logo.html.twig' %}
-                    </section>
-                    <section class="navbar-section desktop-menu">
+                    </div>
+                    <div class="navbar-section desktop-menu">
 
-                        <nav class="dropmenu animated">
+                        <div class="dropmenu animated">
                         {% block header_navigation %}
                             {% include 'partials/navigation.html.twig' %}
                         {% endblock %}
-                        </nav>
+                        </div>
 
                         {% if config.plugins.login.enabled and grav.user.username %}
                             <span class="login-status-wrapper"><i class="fa fa-user"></i> {% include 'partials/login-status.html.twig' %}</span>
                         {% endif %}
 
-                    </section>
+                    </div>
                 </nav>
-            </section>
-        </section>
+            </div>
+        </div>
         <div class="mobile-menu">
-            <div class="button_container" id="toggle">
+            <div class="button_container" id="toggle" aria-expanded="false" aria-controls="overlay">
                 <span class="top"></span>
                 <span class="middle"></span>
                 <span class="bottom"></span>
@@ -73,18 +73,18 @@
 
     {% block hero %}{% endblock %}
 
-        <section id="start">
+        <main id="start">
         {% block body %}
             <section id="body-wrapper" class="section">
-                <section class="container {{ grid_size }}">
+                <div class="container {{ grid_size }}">
                     {% block messages %}
                         {% include 'partials/messages.html.twig' ignore missing %}
                     {% endblock %}
                     {{ block('content_surround') }}
-                </section>
+                </div>
             </section>
         {% endblock %}
-        </section>
+        </main>
 
     </div>
 


### PR DESCRIPTION
## The problem
When a blind persons arrive on a web page in general the person uses TAB to list every link of the main menu. 

However, with this quark theme, submenus are not displayed when the button in charge to collapse or uncollapse get the focus. If the person use the ENTER key, it open the first page of the submenu instead of displaying the sublist of link.

## The solution
Here i try to make this things working better by those ways:

- Use the focus to determine if the submenu should be open.
- Reuse https://github.com/getgrav/grav-theme-quark/pull/23 to manage a bit better the tree menu for mobile
- Limit the number of nav to ease the return into the main nav menu
- Replace section by div (see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section for more info)
> If you are only using the element as a styling wrapper, use a [<div>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div). An unwritten rule is that a <section> should logically appear in the outline of a document.

## Status of this PR
The CSS need to be recompiled, i have not tested the fix directly (but on a derived theme)
I am waiting some return from a bling friend to completely validate this solution.


