### PR TITLE
Fixed error showing mobile logo.

### DIFF
--- a/templates/partials/logo.html.twig
+++ b/templates/partials/logo.html.twig
@@ -1,4 +1,4 @@
-{% set logo = theme_var('custom_logo_mobile' ?: 'custom_logo') %}
+{% set logo = theme_var('custom_logo_mobile') ?: theme_var('custom_logo') %}
 <a href="{{ home_url }}" class="navbar-brand mr-10">
 {% if logo %}
   {% set logo_file = (logo|first).name %}

--- a/templates/partials/logo.html.twig
+++ b/templates/partials/logo.html.twig
@@ -1,4 +1,4 @@
-{% set logo = theme_var(mobile ? 'custom_logo_mobile' : 'custom_logo') %}
+{% set logo = theme_var('custom_logo_mobile' ?: 'custom_logo') %}
 <a href="{{ home_url }}" class="navbar-brand mr-10">
 {% if logo %}
   {% set logo_file = (logo|first).name %}


### PR DESCRIPTION
When only the mobile logo is selected to display, it is not displayed. Instead, the standard logo is always displayed, if it exists, or nothing is displayed, if there is no standard logo.