### PR TITLE
grav-plugin-prism-highlight copy button labels translation added

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -37,7 +37,7 @@
     {{ assets.js()|raw }}
 {% endblock %}
 </head>
-<body id="top" class="{% block body_classes %}{{ body_classes }}{% endblock %}"{% if config.plugins.prism-highlight.enabled %} data-prismjs-copy="{{ 'PLUGIN_PRISM_HIGHLIGHT.COPY'|t }}" data-prismjs-copy-error="{{ 'PLUGIN_PRISM_HIGHLIGHT.COPY_ERROR'|t }}" data-prismjs-copy-success="{{ 'PLUGIN_PRISM_HIGHLIGHT.COPY_SUCCESS'|t }}"{% endif %}>
+<body id="top" class="{% block body_classes %}{{ body_classes }}{% endblock %}"{% if config.plugins['prism-highlight'].enabled %} data-prismjs-copy="{{ 'PLUGIN_PRISM_HIGHLIGHT.COPY'|t }}" data-prismjs-copy-error="{{ 'PLUGIN_PRISM_HIGHLIGHT.COPY_ERROR'|t }}" data-prismjs-copy-success="{{ 'PLUGIN_PRISM_HIGHLIGHT.COPY_SUCCESS'|t }}"{% endif %}>
     <div id="page-wrapper">
     {% block header %}
         <section id="header" class="section">

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -37,7 +37,7 @@
     {{ assets.js()|raw }}
 {% endblock %}
 </head>
-<body id="top" class="{% block body_classes %}{{ body_classes }}{% endblock %}">
+<body id="top" class="{% block body_classes %}{{ body_classes }}{% endblock %}"{% if config.plugins.prism-highlight.enabled %} data-prismjs-copy="{{ 'PLUGIN_PRISM_HIGHLIGHT.COPY'|t }}" data-prismjs-copy-error="{{ 'PLUGIN_PRISM_HIGHLIGHT.COPY_ERROR'|t }}" data-prismjs-copy-success="{{ 'PLUGIN_PRISM_HIGHLIGHT.COPY_SUCCESS'|t }}"{% endif %}>
     <div id="page-wrapper">
     {% block header %}
         <section id="header" class="section">


### PR DESCRIPTION
grav-plugin-prism-highlight copy button labels translation added. Should be applied after https://github.com/trilbymedia/grav-plugin-prism-highlight/pull/14

Related: https://github.com/trilbymedia/grav-plugin-prism-highlight/pull/14
Author-Change-Id: IB#1139768
