### PR TITLE
Update README.md:  Adding note about Gallery module

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   * Features Modular view template `features.md`
   * Hero Modular view template `hero.md`
   * Text Modular view template `text.md`
+  * Note: Gallery Modular view template `gallery.md` only works in concert with premium plugin [Lightbox Gallery](https://getgrav.org/premium/lightbox-gallery/docs)
 
 # Installation
 


### PR DESCRIPTION
The existence of the gallery module is confusing since it only works correctly in concert with the premium Lightbox Gallery plugin.