### PR TITLE
Images get distorted due to img { max-width: 100%; }

### DIFF
--- a/scss/theme/_typography.scss
+++ b/scss/theme/_typography.scss
@@ -59,6 +59,7 @@ a:focus {
 
 img {
   max-width: 100%;
+  width: auto;
 }
 
 // Tables


### PR DESCRIPTION
Images get distorted due to img { max-width: 100%; } without height: auto; 
[Issue #196](https://github.com/getgrav/grav-theme-quark/issues/196)