### PR TITLE
Added frontmatter option to toggle the hero block visibility on blog pages

### DIFF
--- a/blueprints/partials/blog-bits.yaml
+++ b/blueprints/partials/blog-bits.yaml
@@ -16,6 +16,17 @@ form:
       label: Hero Image
       preview_images: true
       description: 'If not specified, this defaults to the first image found in the page''s folder'
+    
+    header.hero_enabled:
+      type: toggle
+      label: Enable Hero Block
+      highlight: 1
+      default: 1
+      options:
+        1: Enabled
+        0: Disabled
+      validate:
+        type: bool
 
     toggles_title:
       type: spacer

--- a/templates/blog.html.twig
+++ b/templates/blog.html.twig
@@ -19,7 +19,9 @@
 
 
 {% block hero %}
-    {% include 'partials/hero.html.twig' with {id: 'blog-hero', content: page.content, hero_image: blog_image} %}
+    {% if page.header.hero_enabled|defined(true) %}
+        {% include 'partials/hero.html.twig' with {id: 'blog-hero', content: page.content, hero_image: blog_image} %}
+    {% endif %}
 {% endblock %}
 
 {% block body %}

--- a/templates/item.html.twig
+++ b/templates/item.html.twig
@@ -4,19 +4,23 @@
 {% set show_sidebar = header_var('show_sidebar', [page, blog])|defined(true)  %}
 {% set show_pagination = header_var('show_pagination', [page, blog])|defined(true) %}
 {% set hero_image_name = page.header.hero_image %}
+{% set hero_enabled = page.header.hero_enabled|defined(true) %}
 
 {% block hero %}
-    {% if hero_image_name %}
-        {% set hero_image = page.media[hero_image_name] %}
+   {% if hero_enabled %}
         {% set content %}
             <h1>{{ page.title }}</h1>
             <h2>{{ page.header.subtitle }}</h2>
             {% include 'partials/blog/date.html.twig' %}
             {% include 'partials/blog/taxonomy.html.twig' %}
         {% endset %}
+    
+        {% if hero_image_name %}
+            {% set hero_image = page.media[hero_image_name] %}
+        {% endif %}
         {% include 'partials/hero.html.twig' with {id: 'blog-hero'} %}
-
     {% endif %}
+    
 {% endblock %}
 
 {% block body %}

--- a/templates/partials/blog-item.html.twig
+++ b/templates/partials/blog-item.html.twig
@@ -1,6 +1,6 @@
 <div class="content-item h-entry">
 
-{% if not hero_image_name %}
+{% if not hero_image_name or hero_enabled == false %}
     <div class="content-title text-center">
         {% include 'partials/blog/title.html.twig' with {title_level: 'h2'} %}
         {% if page.header.subtitle %}


### PR DESCRIPTION
Implemented hero_block.enabled: true/false in blog post frontmatter for flexible hero section management. 

With this PR the [Issue 138](https://github.com/getgrav/grav-theme-quark/issues/138) can be closed.