### PR TITLE
fix(logo): render custom SVG logos inline to preserve styles

### DIFF
--- a/templates/partials/logo.html.twig
+++ b/templates/partials/logo.html.twig
@@ -2,7 +2,13 @@
 <a href="{{ home_url }}" class="navbar-brand mr-10">
 {% if logo %}
   {% set logo_file = (logo|first).name %}
-  <img src="{{ url('theme://images/logo/' ~ logo_file)  }}" alt="{{ site.title }}" />
+        {% set extension = logo_file|split('.')|last %}
+        
+        {% if extension == 'svg' %}
+            {% include('@images/logo/' ~ logo_file) %}
+        {% else %}
+            <img src="{{ url('theme://images/logo/' ~ logo_file) }}" alt="{{ site.title }}" width="auto" height="auto">
+        {% endif %}
 {% else %}
   {% include('@images/grav-logo.svg') %}
 {% endif %}


### PR DESCRIPTION
Previously, custom SVG logos were always loaded via `<img>` which stripped dynamic color and style behavior (e.g. adapting to dark/light backgrounds).

This change inlines SVG files directly, ensuring they behave like the default Grav logo, while other formats (PNG/JPG) remain as <img>.